### PR TITLE
Make compatible with Clojure 1.11.0 onwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented in this file. This change
 ### Changed
 Nothing yet
 
+## [0.0.5] - 2023-08-11
+### Improved
+- Make library compatible with Clojure 1.11.0 and above
 
 ## [0.0.4] - 2021-02-23
 ### Improved
-- `at` has potential to produce an uncaught exception. 
+- `at` has potential to produce an uncaught exception.
    It now throws a custom `ex-info` which provides detailed information about the problem.
 
 ## [0.0.3] - 2020-12-16
@@ -44,7 +47,8 @@ Nothing yet
 ## 0.0.1 - 2019-11-19
 ### Initial release
 
-[Unreleased]: https://github.com/crinklywrappr/gooff/compare/v0.0.4...HEAD
+[Unreleased]: https://github.com/crinklywrappr/gooff/compare/v0.0.5...HEAD
+[0.0.5]: https://github.com/crinklywrappr/gooff/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/crinklywrappr/gooff/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/crinklywrappr/gooff/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/crinklywrappr/gooff/compare/v0.0.1...v0.0.2

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject gooff "0.0.4"
+(defproject gooff "0.0.5"
   :description "KISS scheduling library. Inspired by Snooze"
   :url "https://github.com/doubleagent/gooff"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/gooff/core.clj
+++ b/src/gooff/core.clj
@@ -1,13 +1,12 @@
 (ns gooff.core
+  (:refer-clojure :exclude [parse-long])
   (:require [clj-time.core :as t]
             [clojure.string :as s]))
 
 ;; --- UTIL ---
 
-(defn ^:private parse-long' [s]
-  (if-let [f (resolve 'clojure.core/parse-long)] ;; make compatible with Clojure 1.11.0 onwards
-    (f s)
-    (Long/parseLong s)))
+(defn ^:private parse-long [s]
+  (Long/parseLong s))
 
 ;; --- DATE-TIME ---
 
@@ -200,7 +199,7 @@
 (defn field-range [s]
   (let [[from to] (->> s
                        (re-find range-pattern)
-                       rest (map parse-long'))]
+                       rest (map parse-long))]
     (when (or (nil? from) (nil? to))
       (throw
        (IllegalArgumentException.
@@ -217,7 +216,7 @@
   (let [rep (try
             (-> repetition-pattern
                 (re-find s)
-                last parse-long')
+                last parse-long)
             (catch Exception e
               (throw
                (IllegalArgumentException.
@@ -227,7 +226,7 @@
 (defn field-shifted-repetition [s]
   (let [[shift rep] (->> s
                          (re-find shifted-pattern)
-                         rest (map parse-long'))]
+                         rest (map parse-long))]
     (if (and (some? shift) (some? rep)
              (or (neg? shift) (pos? shift))
              (pos? rep))
@@ -317,8 +316,8 @@
   which the rule function will understand."
   [field]
   (cond
-    (re-find #"^\d+$" field) (parse-long' field)
-    (s/includes? field ",") (map parse-long' (s/split field #","))
+    (re-find #"^\d+$" field) (parse-long field)
+    (s/includes? field ",") (map parse-long (s/split field #","))
     :else field))
 
 (defn substitute-days


### PR DESCRIPTION
This small change checks if the clojure.core/parse-long function is available (from Clojure 1.11.0 onwards) and uses that - otherwise it falls back to using the existing Long/parseLong approach.

fixes #1

-=david=-